### PR TITLE
Add/lazy matching calls

### DIFF
--- a/component.json
+++ b/component.json
@@ -17,8 +17,7 @@
   ],
   "dependencies": {
     "yields/eql": "*",
-    "yields/merge": "*",
-    "component/each": "*"
+    "yields/merge": "*"
   },
   "development": {
     "component/assert": "*"

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
  */
 
 var merge = require('merge');
-var each = require('each');
 var eql = require('eql');
 
 /**


### PR DESCRIPTION
cc @lancejpollard @yields makes it so that it can match any of the calls that happened. And switches to do lazy matching by default, with `Exactly` methods added for precision. Kept old lazy ones for backwards compat for now
